### PR TITLE
Fix header display on about and detail screens

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -5,6 +5,8 @@ export default function Layout() {
     <Stack>
       <Stack.Screen name="index" options={{ headerShown: false }} />
       <Stack.Screen name="home" options={{ headerShown: false }} />
+      <Stack.Screen name="about" options={{ headerShown: false }} />
+      <Stack.Screen name="detail" options={{ headerShown: false }} />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- ensure about.js and detail.js hide the navigation header

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862af7555b0832a8ec77605df613950